### PR TITLE
Feature/#69/store layout

### DIFF
--- a/src/components/StoreCard.tsx
+++ b/src/components/StoreCard.tsx
@@ -1,7 +1,10 @@
 import Image from 'next/image'
-import { StoresQuery } from 'src/graphql/generated/types-and-hooks'
+import { StoresQuery, useStoreQuery } from 'src/graphql/generated/types-and-hooks'
+
 import { ArrayElement } from 'src/utils/types'
 import styled from 'styled-components'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 const FlexContainerLi = styled.li`
   display: flex;
@@ -70,15 +73,21 @@ type Props = {
 }
 
 function StoreCard({ store }: Props) {
+  const router = useRouter()
+
+  const storeId = (router.query.id ?? '') as string
+
   return (
     <FlexContainerLi>
       <CardImage>
-        <Image
-          src={store.imageUrls?.[0] ?? '/images/default-store-cover.png'}
-          alt={store.name ?? 'store-cover'}
-          layout="fill"
-          objectFit="cover"
-        />
+        <Link href={`/stores/${storeId}`} passHref>
+          <Image
+            src={store.imageUrls?.[0] ?? '/images/default-store-cover.png'}
+            alt={store.name ?? 'store-cover'}
+            layout="fill"
+            objectFit="cover"
+          />
+        </Link>
         <LikeButton>
           <Image src="/images/like.min.svg" alt="like" layout="fill" />
         </LikeButton>

--- a/src/layouts/StoreLayout.tsx
+++ b/src/layouts/StoreLayout.tsx
@@ -24,7 +24,7 @@ const TabsContainer = styled.div`
   border: solid 1px #f0f0f0;
 `
 
-const Tab = styled.div`
+const Tab = styled.a`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -74,14 +74,19 @@ export default function StoreLayout({ children }: Props) {
         '결과 없음'
       )}
       <TabsContainer>
-        <Tab>
-          <Link href={`/stores/${storeId}`}>정보</Link>{' '}
-        </Tab>
-        <Link href={`/stores/${storeId}/news`}>소식</Link>{' '}
-        <Link href={`/stores/${storeId}/feed`}>피드</Link>{' '}
-        <Link href={`/stores/${storeId}/menus`}>메뉴</Link>{' '}
+        <Link href={`/stores/${storeId}`} passHref>
+          <Tab>정보</Tab>
+        </Link>{' '}
+        <Link href={`/stores/${storeId}/news`} passHref>
+          <Tab>소식</Tab>
+        </Link>{' '}
+        <Link href={`/stores/${storeId}/menus`} passHref>
+          <Tab>메뉴</Tab>
+        </Link>{' '}
+        <Link href={`/stores/${storeId}/feed`} passHref>
+          <Tab>피드</Tab>
+        </Link>{' '}
       </TabsContainer>
-
       {children}
     </StoreContainer>
   )

--- a/src/layouts/StoreLayout.tsx
+++ b/src/layouts/StoreLayout.tsx
@@ -1,4 +1,5 @@
 import { HeartOutlined, HeartTwoTone } from '@ant-design/icons'
+import { SignalWifi1BarLock } from '@material-ui/icons'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -15,7 +16,7 @@ type Props = {
 const StoreContainer = styled.div`
   background-color: #fcfcfc;
 `
-const TabsContainer = styled.div`
+const TabsContainer = styled.ul`
   display: flex;
   justify-content: space-around;
   align-items: center;
@@ -24,21 +25,31 @@ const TabsContainer = styled.div`
   border: solid 1px #f0f0f0;
 `
 
-const Tab = styled.a`
+const Tab = styled.li`
   display: flex;
   justify-content: center;
   align-items: center;
-  color: black !important;
   font-size: 1.1rem;
   width: 49px;
   height: 100%;
   padding: auto;
-  border-bottom: solid 5px #5d5d5d;
+  cursor: pointer;
+  transition: ease 0.5s;
+  &:hover {
+    color: black;
+    border-bottom: 'solid 5px #5d5d5d';
+  }
 `
+
+const SelectedTabStyle = { color: '#000000', borderBottom: 'solid 5px #5d5d5d' }
+const UnSelectedTabStyle = { color: '#8e8e8e', borderBottom: 'solid 5px white' }
+
 export default function StoreLayout({ children }: Props) {
   const setStore = useSetRecoilState(storeRecoil)
 
   const router = useRouter()
+
+  const { asPath } = useRouter()
 
   const storeId = (router.query.id ?? '') as string
 
@@ -75,16 +86,26 @@ export default function StoreLayout({ children }: Props) {
       )}
       <TabsContainer>
         <Link href={`/stores/${storeId}`} passHref>
-          <Tab>정보</Tab>
+          <Tab style={asPath === `/stores/${storeId}` ? SelectedTabStyle : UnSelectedTabStyle}>
+            정보
+          </Tab>
         </Link>{' '}
         <Link href={`/stores/${storeId}/news`} passHref>
-          <Tab>소식</Tab>
+          <Tab style={asPath === `/stores/${storeId}/news` ? SelectedTabStyle : UnSelectedTabStyle}>
+            소식
+          </Tab>
         </Link>{' '}
         <Link href={`/stores/${storeId}/menus`} passHref>
-          <Tab>메뉴</Tab>
+          <Tab
+            style={asPath === `/stores/${storeId}/menus` ? SelectedTabStyle : UnSelectedTabStyle}
+          >
+            메뉴
+          </Tab>
         </Link>{' '}
         <Link href={`/stores/${storeId}/feed`} passHref>
-          <Tab>피드</Tab>
+          <Tab style={asPath === `/stores/${storeId}/feed` ? SelectedTabStyle : UnSelectedTabStyle}>
+            피드
+          </Tab>
         </Link>{' '}
       </TabsContainer>
       {children}

--- a/src/layouts/StoreLayout.tsx
+++ b/src/layouts/StoreLayout.tsx
@@ -1,5 +1,4 @@
 import { HeartOutlined, HeartTwoTone } from '@ant-design/icons'
-import { SignalWifi1BarLock } from '@material-ui/icons'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'

--- a/src/layouts/StoreLayout.tsx
+++ b/src/layouts/StoreLayout.tsx
@@ -44,6 +44,30 @@ const Tab = styled.li`
 const SelectedTabStyle = { color: '#000000', borderBottom: 'solid 5px #5d5d5d' }
 const UnSelectedTabStyle = { color: '#8e8e8e', borderBottom: 'solid 5px white' }
 
+const StoreHeaderContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 5rem;
+  padding: 1rem 0;
+`
+
+const LikedButton = styled.div`
+  position: absolute;
+  top: 0.5%;
+  left: 94%;
+  //margin: 5px;
+`
+
+const StoreName = styled.div`
+  font-size: 1.3rem;
+  font-weight: 500;
+`
+const StoreDescription = styled.div`
+  font-size: 1.1rem;
+  color: #5d5d5d;
+`
 export default function StoreLayout({ children }: Props) {
   const setStore = useSetRecoilState(storeRecoil)
 
@@ -69,18 +93,20 @@ export default function StoreLayout({ children }: Props) {
       <Image
         src={store?.imageUrls?.[0] ?? '/images/default-store-cover.png'}
         alt="store-cover"
-        width="200"
-        height="200"
+        width="1080"
+        height="606"
         objectFit="cover"
       />
       {loading ? (
         'loading...'
       ) : store ? (
-        <>
-          <h2>{storeName}</h2>
-          <div>{store.description}</div>
-          <div>{store.isLiked ? <HeartTwoTone twoToneColor="#ff9f74" /> : <HeartOutlined />}</div>
-        </>
+        <StoreHeaderContainer>
+          <StoreName>{storeName}</StoreName>
+          <StoreDescription>{store.description}</StoreDescription>
+          <LikedButton>
+            {store.isLiked ? <HeartTwoTone twoToneColor="#ff9f74" /> : <HeartOutlined />}
+          </LikedButton>
+        </StoreHeaderContainer>
       ) : (
         '결과 없음'
       )}

--- a/src/layouts/StoreLayout.tsx
+++ b/src/layouts/StoreLayout.tsx
@@ -115,24 +115,24 @@ export default function StoreLayout({ children }: Props) {
           <Tab style={asPath === `/stores/${storeId}` ? SelectedTabStyle : UnSelectedTabStyle}>
             정보
           </Tab>
-        </Link>{' '}
+        </Link>
         <Link href={`/stores/${storeId}/news`} passHref>
           <Tab style={asPath === `/stores/${storeId}/news` ? SelectedTabStyle : UnSelectedTabStyle}>
             소식
           </Tab>
-        </Link>{' '}
+        </Link>
         <Link href={`/stores/${storeId}/menus`} passHref>
           <Tab
             style={asPath === `/stores/${storeId}/menus` ? SelectedTabStyle : UnSelectedTabStyle}
           >
             메뉴
           </Tab>
-        </Link>{' '}
+        </Link>
         <Link href={`/stores/${storeId}/feed`} passHref>
           <Tab style={asPath === `/stores/${storeId}/feed` ? SelectedTabStyle : UnSelectedTabStyle}>
             피드
           </Tab>
-        </Link>{' '}
+        </Link>
       </TabsContainer>
       {children}
     </StoreContainer>

--- a/src/layouts/StoreLayout.tsx
+++ b/src/layouts/StoreLayout.tsx
@@ -6,11 +6,35 @@ import { ReactNode, useEffect } from 'react'
 import { useSetRecoilState } from 'recoil'
 import { useStoreQuery } from 'src/graphql/generated/types-and-hooks'
 import { store as storeRecoil } from 'src/models/recoil'
+import styled from 'styled-components'
 
 type Props = {
   children: ReactNode
 }
 
+const StoreContainer = styled.div`
+  background-color: #fcfcfc;
+`
+const TabsContainer = styled.div`
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  height: 50px;
+  background-color: white;
+  border: solid 1px #f0f0f0;
+`
+
+const Tab = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: black !important;
+  font-size: 1.1rem;
+  width: 49px;
+  height: 100%;
+  padding: auto;
+  border-bottom: solid 5px #5d5d5d;
+`
 export default function StoreLayout({ children }: Props) {
   const setStore = useSetRecoilState(storeRecoil)
 
@@ -30,7 +54,7 @@ export default function StoreLayout({ children }: Props) {
   }, [setStore, storeId, storeName])
 
   return (
-    <div>
+    <StoreContainer>
       <Image
         src={store?.imageUrls?.[0] ?? '/images/default-store-cover.png'}
         alt="store-cover"
@@ -49,14 +73,16 @@ export default function StoreLayout({ children }: Props) {
       ) : (
         '결과 없음'
       )}
-      <div>
-        <Link href={`/stores/${storeId}`}>정보</Link>{' '}
+      <TabsContainer>
+        <Tab>
+          <Link href={`/stores/${storeId}`}>정보</Link>{' '}
+        </Tab>
         <Link href={`/stores/${storeId}/news`}>소식</Link>{' '}
         <Link href={`/stores/${storeId}/feed`}>피드</Link>{' '}
         <Link href={`/stores/${storeId}/menus`}>메뉴</Link>{' '}
-      </div>
+      </TabsContainer>
 
       {children}
-    </div>
+    </StoreContainer>
   )
 }

--- a/src/layouts/StoreLayout.tsx
+++ b/src/layouts/StoreLayout.tsx
@@ -18,8 +18,9 @@ const StoreContainer = styled.div`
 `
 const TabsContainer = styled.ul`
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
   align-items: center;
+  padding: 0 1rem;
   height: 50px;
   background-color: white;
   border: solid 1px #f0f0f0;

--- a/src/pages/stores/[id]/index.tsx
+++ b/src/pages/stores/[id]/index.tsx
@@ -4,6 +4,7 @@ import PageHead from 'src/components/PageHead'
 import { useStoreDetailQuery } from 'src/graphql/generated/types-and-hooks'
 import StoreLayout from 'src/layouts/StoreLayout'
 import { store } from 'src/models/recoil'
+import styled from 'styled-components'
 
 const description = ''
 


### PR DESCRIPTION
Close #69

## Description

<!-- 이 PR이 해결하는 문제. 기존의 기능을 변경한 경우, 1. 기존 기능의 작동, 2. 어떻게 고쳤는가, 3. 왜 고쳤는가를 포함해주세요. 필요에 따라 스크린샷도 첨부해주세요! -->
![image](https://user-images.githubusercontent.com/60775453/132344628-6cdd9f6f-5e9a-4db8-be40-cc3ee56204b7.png)
Store home layout을 만들었습니다.
특히, tab을 useRouter를 이용하여 직접 구현했습니다.

## Help Wanted 👀
<!-- 도움이 필요한 부분들을 적어주세요. -->
홈 화면에서 매장 이미지를 클릭했을 때 해당 매장 홈으로 이동해야하는데
`stores/` 에서 끝나네요.
useEffect를 써야하는지, store 쿼리를 StoreCard에서 불러와도 되는지 몰라서 우선 진행중입니다.
혹시 아는게 있다면 댓글 부탁드려요!

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
